### PR TITLE
deep link meeting url first time open fix

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -111,7 +111,7 @@ class _HMSExampleAppState extends State<HMSExampleApp> {
         if (!mounted) {
           return;
         }
-        if (uri == null) {
+        if (uri == null || !uri.toString().contains("100ms.live")) {
           return;
         }
         setState(() {


### PR DESCRIPTION
Fixes:
 - Download app from store and open it from meeting url giving wrong text fixed.