### PR TITLE
Added actionListener in switch camera api

### DIFF
--- a/example/lib/data_store/meeting_store.dart
+++ b/example/lib/data_store/meeting_store.dart
@@ -199,7 +199,7 @@ class MeetingStore extends ChangeNotifier
 
   Future<void> switchCamera() async {
     if (isVideoOn) {
-      await _hmsSDKInteractor.switchCamera();
+      await _hmsSDKInteractor.switchCamera(hmsActionResultListener: this);
     }
   }
 


### PR DESCRIPTION
Fixes : 

- Added actionResultListener in `switchCamera` api in example app.
- The sdk changes are already done.