### PR TITLE
Removed speakers with peer or track null in onUpdateSpeaker

### DIFF
--- a/android/src/main/kotlin/live/hms/hmssdk_flutter/HMSSpeakerExtension.kt
+++ b/android/src/main/kotlin/live/hms/hmssdk_flutter/HMSSpeakerExtension.kt
@@ -8,8 +8,13 @@ class HMSSpeakerExtension {
             val hashMap = HashMap<String,Any?>()
             if(speaker==null)return null
             hashMap.put("audioLevel",speaker.level)
-            hashMap.put("track",HMSTrackExtension.toDictionary(speaker.hmsTrack))
-            hashMap.put("peer",HMSPeerExtension.toDictionary(speaker.peer))
+            val hmsTrackMap = HMSTrackExtension.toDictionary(speaker.hmsTrack)
+            val hmsPeerMap = HMSPeerExtension.toDictionary(speaker.peer)
+            if((hmsTrackMap == null) || (hmsPeerMap == null)){
+                return null
+            }
+            hashMap.put("track",hmsTrackMap)
+            hashMap.put("peer",hmsPeerMap)
             return hashMap
         }
     }

--- a/android/src/main/kotlin/live/hms/hmssdk_flutter/HmssdkFlutterPlugin.kt
+++ b/android/src/main/kotlin/live/hms/hmssdk_flutter/HmssdkFlutterPlugin.kt
@@ -570,7 +570,10 @@ class HmssdkFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware,
 
             if (speakers.isNotEmpty()) {
                 speakers.forEach {
-                    speakersList.add(HMSSpeakerExtension.toDictionary(it)!!)
+                    val hmsSpeakerMap = HMSSpeakerExtension.toDictionary(it)
+                    if(hmsSpeakerMap != null){
+                        speakersList.add(hmsSpeakerMap!!)
+                    }
                 }
             }
             val speakersMap = HashMap<String, Any>()

--- a/lib/src/model/hms_speaker.dart
+++ b/lib/src/model/hms_speaker.dart
@@ -3,15 +3,13 @@ import 'package:hmssdk_flutter/hmssdk_flutter.dart';
 
 class HMSSpeaker {
   final HMSPeer peer;
-  final HMSTrack? track;
+  final HMSTrack track;
   final int audioLevel;
 
   factory HMSSpeaker.fromMap(Map data) {
     return new HMSSpeaker(
       peer: HMSPeer.fromMap(data['peer']),
-      track: data["track"] == null
-          ? null
-          : data['track']['instance_of']
+      track: data['track']['instance_of']
               ? HMSVideoTrack.fromMap(map: data['track'])
               : HMSAudioTrack.fromMap(map: data['track']),
       audioLevel: data['audioLevel'] as int,


### PR DESCRIPTION
Fixes : 

- Made `HMSTrack` non-nullable in `HMSSpeaker`
- Speaker updates are only sent if peer and track are not null

Closes #887 