### PR TITLE
Added code to manually dispose surface view and avoid rebuilds

### DIFF
--- a/android/src/main/kotlin/live/hms/hmssdk_flutter/views/HMSVideoView.kt
+++ b/android/src/main/kotlin/live/hms/hmssdk_flutter/views/HMSVideoView.kt
@@ -35,6 +35,12 @@ class HMSVideoView(
         }
     }
 
+    fun onDisposeCalled(){
+        super.onDetachedFromWindow()
+        track.removeSink(surfaceViewRenderer)
+        surfaceViewRenderer.release()
+    }
+
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
         surfaceViewRenderer.init(SharedEglContext.context, null)

--- a/android/src/main/kotlin/live/hms/hmssdk_flutter/views/HMSVideoViewFactory.kt
+++ b/android/src/main/kotlin/live/hms/hmssdk_flutter/views/HMSVideoViewFactory.kt
@@ -46,6 +46,7 @@ class HMSVideoViewWidget(private val context: Context, id: Int, creationParams: 
     }
 
     override fun dispose() {
+        hmsVideoView?.onDisposeCalled();
         hmsVideoView = null
     }
 }

--- a/example/lib/common/ui/organisms/audio_level_avatar.dart
+++ b/example/lib/common/ui/organisms/audio_level_avatar.dart
@@ -17,11 +17,10 @@ class _AudioLevelAvatarState extends State<AudioLevelAvatar> {
   @override
   Widget build(BuildContext context) {
     return Center(
-      child: Selector<MeetingStore, int>(
-          selector: (_, meetingStore) =>
-              meetingStore.isActiveSpeaker(context.read<PeerTrackNode>().uid),
-          builder: (_, isSpeaking, __) {
-            return isSpeaking == -1
+      child: Selector<PeerTrackNode, int>(
+          selector: (_, peerTrackNode) => peerTrackNode.audioLevel,
+          builder: (_, audioLevel, __) {
+            return audioLevel == -1
                 ? CircleAvatar(
                     backgroundColor: Utilities.getBackgroundColour(
                         context.read<PeerTrackNode>().peer.name),
@@ -37,7 +36,7 @@ class _AudioLevelAvatarState extends State<AudioLevelAvatar> {
                     showTwoGlows: true,
                     duration: Duration(seconds: 1),
                     endRadius:
-                        (isSpeaking != -1) ? 36 + (isSpeaking).toDouble() : 36,
+                        (audioLevel != -1) ? 36 + (audioLevel).toDouble() : 36,
                     glowColor: Utilities.getBackgroundColour(
                         context.read<PeerTrackNode>().peer.name),
                     child: CircleAvatar(

--- a/example/lib/common/ui/organisms/tile_border.dart
+++ b/example/lib/common/ui/organisms/tile_border.dart
@@ -1,6 +1,7 @@
 //Package imports
 import 'package:flutter/material.dart';
 import 'package:hmssdk_flutter_example/common/util/app_color.dart';
+import 'package:hmssdk_flutter_example/model/peer_track_node.dart';
 import 'package:provider/provider.dart';
 
 //Project imports
@@ -21,18 +22,18 @@ class TileBorder extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Selector<MeetingStore, int>(
-        selector: (_, meetingStore) => meetingStore.isActiveSpeaker(uid),
-        builder: (_, isHighestSpeaker, __) {
+    return Selector<PeerTrackNode, int>(
+        selector: (_, peerTrackNode) => peerTrackNode.audioLevel,
+        builder: (_, audioLevel, __) {
           return Container(
             height: itemHeight + 110,
             width: itemWidth - 4,
             decoration: BoxDecoration(
               border: Border.all(
-                  color: (isHighestSpeaker != -1)
+                  color: (audioLevel != -1)
                       ? Utilities.getBackgroundColour(name)
                       : themeBottomSheetColor,
-                  width: (isHighestSpeaker != -1) ? 4.0 : 0.0),
+                  width: (audioLevel != -1) ? 4.0 : 0.0),
               borderRadius: BorderRadius.all(Radius.circular(10)),
             ),
           );

--- a/example/lib/hls-streaming/bottom_sheets/hls_device_settings.dart
+++ b/example/lib/hls-streaming/bottom_sheets/hls_device_settings.dart
@@ -126,11 +126,13 @@ class _HLSDeviceSettingsState extends State<HLSDeviceSettings> {
                       offset: Offset(-10, -10),
                       iconEnabledColor: iconColor,
                       onChanged: (dynamic newvalue) {
-                        if (newvalue != null)
+                        if (newvalue != null){
+                          Navigator.pop(context);
                           context
                               .read<MeetingStore>()
                               .switchAudioOutput(audioDevice: newvalue);
                         dropdownKey = null;
+                        }
                       },
                       items: <DropdownMenuItem>[
                         ...data.item1

--- a/example/lib/hls-streaming/meeting_mode/hls_grid_view.dart
+++ b/example/lib/hls-streaming/meeting_mode/hls_grid_view.dart
@@ -24,7 +24,7 @@ Widget hlsGridView(
     required Size size}) {
   return GridView.builder(
       shrinkWrap: true,
-      cacheExtent: size.width,
+      cacheExtent: 0,
       itemCount: itemCount,
       scrollDirection: Axis.horizontal,
       physics: PageScrollPhysics(),

--- a/example/lib/hls-streaming/meeting_mode/hls_grid_view.dart
+++ b/example/lib/hls-streaming/meeting_mode/hls_grid_view.dart
@@ -24,7 +24,8 @@ Widget hlsGridView(
     required Size size}) {
   return GridView.builder(
       shrinkWrap: true,
-      cacheExtent: 0,
+      addAutomaticKeepAlives: false,
+      addRepaintBoundaries: false,
       itemCount: itemCount,
       scrollDirection: Axis.horizontal,
       physics: PageScrollPhysics(),

--- a/example/lib/hls-streaming/util/hls_message_organism.dart
+++ b/example/lib/hls-streaming/util/hls_message_organism.dart
@@ -50,7 +50,7 @@ class HLSMessageOrganism extends StatelessWidget {
                                 maxWidth:
                                     role != "" ? width * 0.25 : width * 0.5),
                             child: HLSTitleText(
-                              text: senderName ?? "",
+                              text: senderName ?? "Anonymous",
                               fontSize: 14,
                               letterSpacing: 0.1,
                               lineHeight: 20,

--- a/example/lib/hms_sdk_interactor.dart
+++ b/example/lib/hms_sdk_interactor.dart
@@ -36,7 +36,7 @@ class HMSSDKInteractor {
     HMSLogSettings hmsLogSettings = HMSLogSettings(
         maxDirSizeInBytes: 1000000,
         isLogStorageEnabled: true,
-        level: HMSLogLevel.VERBOSE);
+        level: HMSLogLevel.OFF);
     hmsSDK = HMSSDK(
         appGroup: appGroup,
         preferredExtension: preferredExtension,

--- a/example/lib/model/peer_track_node.dart
+++ b/example/lib/model/peer_track_node.dart
@@ -13,6 +13,7 @@ class PeerTrackNode extends ChangeNotifier {
   bool isOffscreen;
   int? networkQuality;
   RTCStats? stats;
+  int audioLevel;
 
   PeerTrackNode(
       {required this.peer,
@@ -21,7 +22,8 @@ class PeerTrackNode extends ChangeNotifier {
       required this.uid,
       this.isOffscreen = true,
       this.networkQuality = -1,
-      this.stats});
+      this.stats,
+      this.audioLevel = -1});
 
   @override
   String toString() {
@@ -40,6 +42,22 @@ class PeerTrackNode extends ChangeNotifier {
     notify();
   }
 
+  void setAudioLevel(int audioLevel) {
+    this.audioLevel = audioLevel;
+    if (!this.isOffscreen) {
+      notify();
+    }
+  }
+
+  void setNetworkQuality(int? networkQuality) {
+    if (networkQuality != null) {
+      this.networkQuality = networkQuality;
+      if (!this.isOffscreen) {
+        notify();
+      }
+    }
+  }
+  
   @override
   bool operator ==(Object other) {
     return super == other;


### PR DESCRIPTION
Fixes : 

- Removed `notifyListeners` from places where it was not required
- Added setters for `PeerTrackNode`
- Added method to manually dispose the surfaceViewRenderer