### PR TITLE
Updated metadata parameter

### DIFF
--- a/example/lib/data_store/meeting_store.dart
+++ b/example/lib/data_store/meeting_store.dart
@@ -1248,7 +1248,7 @@ class MeetingStore extends ChangeNotifier
     audioPlayerVolume = volume;
   }
 
-  void setSessionMetadata(String metadata) {
+  void setSessionMetadata(String? metadata) {
     _hmsSDKInteractor.setSessionMetadata(
         metadata: metadata, hmsActionResultListener: this);
   }

--- a/example/lib/hls-streaming/bottom_sheets/hls_message.dart
+++ b/example/lib/hls-streaming/bottom_sheets/hls_message.dart
@@ -345,7 +345,7 @@ class _HLSMessageState extends State<HLSMessage> {
                                     onTap: () {
                                       context
                                           .read<MeetingStore>()
-                                          .setSessionMetadata("");
+                                          .setSessionMetadata(null);
                                     },
                                     child: SvgPicture.asset(
                                         "assets/icons/close.svg"))

--- a/example/lib/hms_sdk_interactor.dart
+++ b/example/lib/hms_sdk_interactor.dart
@@ -338,7 +338,7 @@ class HMSSDKInteractor {
   }
 
   void setSessionMetadata(
-      {required String metadata,
+      {required String? metadata,
       HMSActionResultListener? hmsActionResultListener}) {
     hmsSDK.setSessionMetadata(
         metadata: metadata, hmsActionResultListener: hmsActionResultListener);

--- a/ios/Classes/SwiftHmssdkFlutterPlugin.swift
+++ b/ios/Classes/SwiftHmssdkFlutterPlugin.swift
@@ -755,7 +755,7 @@ public class SwiftHmssdkFlutterPlugin: NSObject, FlutterPlugin, HMSUpdateListene
 
         let arguments = call.arguments as! [AnyHashable: Any]
 
-        guard let metadata = arguments["session_metadata"] as? String else {
+        guard var metadata = arguments["session_metadata"] as? String? ?? "" else {
             result(HMSErrorExtension.getError("No session metadata found in \(#function)"))
             return
         }

--- a/lib/src/hmssdk.dart
+++ b/lib/src/hmssdk.dart
@@ -862,7 +862,7 @@ class HMSSDK {
 
   /// Method to update the value of the session metadata.
   Future<void> setSessionMetadata(
-      {required String metadata,
+      {required String? metadata,
       HMSActionResultListener? hmsActionResultListener}) async {
     var arguments = {"session_metadata": metadata};
     var result = await PlatformService.invokeMethod(


### PR DESCRIPTION
Fixes :

- `metadata` parameter can be null in `setSessionMetadata` method.