### PR TITLE
Added error logs if track is null

### DIFF
--- a/android/src/main/kotlin/live/hms/hmssdk_flutter/HMSRtcStatsExtension.kt
+++ b/android/src/main/kotlin/live/hms/hmssdk_flutter/HMSRtcStatsExtension.kt
@@ -12,9 +12,8 @@ class HMSRtcStatsExtension {
 
     companion object {
 
-        fun toDictionary(hmsRemoteVideoStats: HMSRemoteVideoStats, track: HMSTrack?, peer: HMSPeer?): HashMap<String, Any?>? {
+        fun toDictionary(hmsRemoteVideoStats: HMSRemoteVideoStats, track: HMSTrack, peer: HMSPeer): HashMap<String, Any?> {
             val args = HashMap<String, Any?>()
-            if (peer == null || track == null)return null
             args.put("peer", HMSPeerExtension.toDictionary(peer)!!)
             args.put("track", HMSTrackExtension.toDictionary(track)!!)
 
@@ -31,9 +30,8 @@ class HMSRtcStatsExtension {
             return args
         }
 
-        fun toDictionary(hmsRemoteAudioStats: HMSRemoteAudioStats, track: HMSTrack?, peer: HMSPeer?): HashMap<String, Any?>? {
+        fun toDictionary(hmsRemoteAudioStats: HMSRemoteAudioStats, track: HMSTrack, peer: HMSPeer): HashMap<String, Any?> {
             val args = HashMap<String, Any?>()
-            if (peer == null || track == null)return null
             args.put("peer", HMSPeerExtension.toDictionary(peer)!!)
             args.put("track", HMSTrackExtension.toDictionary(track)!!)
 
@@ -48,9 +46,8 @@ class HMSRtcStatsExtension {
             return args
         }
 
-        fun toDictionary(hmsLocalAudioStats: HMSLocalAudioStats, track: HMSTrack?, peer: HMSPeer?): HashMap<String, Any?>? {
+        fun toDictionary(hmsLocalAudioStats: HMSLocalAudioStats, track: HMSTrack, peer: HMSPeer): HashMap<String, Any?> {
             val args = HashMap<String, Any?>()
-            if (peer == null || track == null)return null
             args.put("peer", HMSPeerExtension.toDictionary(peer)!!)
             args.put("track", HMSTrackExtension.toDictionary(track)!!)
 
@@ -62,9 +59,8 @@ class HMSRtcStatsExtension {
             return args
         }
 
-        fun toDictionary(hmsLocalVideoStats: List<HMSLocalVideoStats>, track: HMSTrack?, peer: HMSPeer?): HashMap<String, Any?>? {
+        fun toDictionary(hmsLocalVideoStats: List<HMSLocalVideoStats>, track: HMSTrack, peer: HMSPeer): HashMap<String, Any?> {
             val args = HashMap<String, Any?>()
-            if (peer == null || track == null)return null
             args["peer"] = HMSPeerExtension.toDictionary(peer)!!
             args["track"] = HMSTrackExtension.toDictionary(track)!!
 
@@ -86,7 +82,7 @@ class HMSRtcStatsExtension {
             return args
         }
 
-        fun toDictionary(qualityLimitationReason: QualityLimitationReasons): HashMap<String, Any?>? {
+        fun toDictionary(qualityLimitationReason: QualityLimitationReasons): HashMap<String, Any?> {
             val qualityLimitationReasonMap = HashMap<String, Any?>()
             qualityLimitationReasonMap["band_width"] = qualityLimitationReason.bandWidth
             qualityLimitationReasonMap["cpu"] = qualityLimitationReason.cpu

--- a/android/src/main/kotlin/live/hms/hmssdk_flutter/HmssdkFlutterPlugin.kt
+++ b/android/src/main/kotlin/live/hms/hmssdk_flutter/HmssdkFlutterPlugin.kt
@@ -1091,6 +1091,7 @@ class HmssdkFlutterPlugin :
             hmsPeer: HMSPeer?
         ) {
             if (hmsPeer == null || hmsTrack == null){
+                Log.e("onRemoteVideoStats err", "peer or track is null")
                 return
             }
             val args = HashMap<String, Any?>()
@@ -1113,6 +1114,7 @@ class HmssdkFlutterPlugin :
             hmsPeer: HMSPeer?
         ) {
             if (hmsPeer == null || hmsTrack == null){
+                Log.e("onRemoteAudioStats err", "peer or track is null")
                 return
             }
             val args = HashMap<String, Any?>()
@@ -1136,6 +1138,7 @@ class HmssdkFlutterPlugin :
             hmsPeer: HMSPeer?
         ) {
             if (hmsPeer == null || hmsTrack == null){
+                Log.e("onLocalVideoStats err", "peer or track is null")
                 return
             }
             val args = HashMap<String, Any?>()
@@ -1159,6 +1162,7 @@ class HmssdkFlutterPlugin :
             hmsPeer: HMSPeer?
         ) {
             if (hmsPeer == null || hmsTrack == null){
+                Log.e("onLocalAudioStats err", "peer or track is null")
                 return
             }
             val args = HashMap<String, Any?>()

--- a/android/src/main/kotlin/live/hms/hmssdk_flutter/HmssdkFlutterPlugin.kt
+++ b/android/src/main/kotlin/live/hms/hmssdk_flutter/HmssdkFlutterPlugin.kt
@@ -935,6 +935,14 @@ class HmssdkFlutterPlugin :
         )
     }
 
+    public fun onVideoViewError(args:HashMap<String, Any?>){
+        if (args["data"] != null) {
+            CoroutineScope(Dispatchers.Main).launch {
+                eventSink?.success(args)
+            }
+        }
+    }
+
     private var androidScreenshareResult: Result? = null
 
     private fun startScreenShare(result: Result) {
@@ -1082,6 +1090,9 @@ class HmssdkFlutterPlugin :
             hmsTrack: HMSTrack?,
             hmsPeer: HMSPeer?
         ) {
+            if (hmsPeer == null || hmsTrack == null){
+                return
+            }
             val args = HashMap<String, Any?>()
             args["event_name"] = "on_remote_video_stats"
             args["data"] = HMSRtcStatsExtension.toDictionary(
@@ -1089,7 +1100,6 @@ class HmssdkFlutterPlugin :
                 peer = hmsPeer,
                 track = hmsTrack
             )
-
             if (args["data"] != null) {
                 CoroutineScope(Dispatchers.Main).launch {
                     rtcSink?.success(args)
@@ -1102,6 +1112,9 @@ class HmssdkFlutterPlugin :
             hmsTrack: HMSTrack?,
             hmsPeer: HMSPeer?
         ) {
+            if (hmsPeer == null || hmsTrack == null){
+                return
+            }
             val args = HashMap<String, Any?>()
             args["event_name"] = "on_remote_audio_stats"
             args["data"] = HMSRtcStatsExtension.toDictionary(
@@ -1122,11 +1135,14 @@ class HmssdkFlutterPlugin :
             hmsTrack: HMSTrack?,
             hmsPeer: HMSPeer?
         ) {
+            if (hmsPeer == null || hmsTrack == null){
+                return
+            }
             val args = HashMap<String, Any?>()
             args["event_name"] = "on_local_video_stats"
             args["data"] = HMSRtcStatsExtension.toDictionary(
                 hmsLocalVideoStats = videoStats,
-                peer = getLocalPeer(),
+                peer = hmsPeer,
                 track = hmsTrack
             )
 
@@ -1142,11 +1158,14 @@ class HmssdkFlutterPlugin :
             hmsTrack: HMSTrack?,
             hmsPeer: HMSPeer?
         ) {
+            if (hmsPeer == null || hmsTrack == null){
+                return
+            }
             val args = HashMap<String, Any?>()
             args["event_name"] = "on_local_audio_stats"
             args["data"] = HMSRtcStatsExtension.toDictionary(
                 hmsLocalAudioStats = audioStats,
-                peer = getLocalPeer(),
+                peer = hmsPeer,
                 track = hmsTrack
             )
 

--- a/android/src/main/kotlin/live/hms/hmssdk_flutter/HmssdkFlutterPlugin.kt
+++ b/android/src/main/kotlin/live/hms/hmssdk_flutter/HmssdkFlutterPlugin.kt
@@ -935,7 +935,7 @@ class HmssdkFlutterPlugin :
         )
     }
 
-    public fun onVideoViewError(args:HashMap<String, Any?>){
+    public fun onVideoViewError(args: HashMap<String, Any?>) {
         if (args["data"] != null) {
             CoroutineScope(Dispatchers.Main).launch {
                 eventSink?.success(args)
@@ -1090,10 +1090,16 @@ class HmssdkFlutterPlugin :
             hmsTrack: HMSTrack?,
             hmsPeer: HMSPeer?
         ) {
-            if (hmsPeer == null || hmsTrack == null){
-                Log.e("onRemoteVideoStats err", "peer or track is null")
+            if (hmsPeer == null) {
+                Log.e("onRemoteVideoStats error", "Peer is null")
                 return
             }
+
+            if (hmsTrack == null) {
+                Log.e("onRemoteVideoStats error", "Video Track is null")
+                return
+            }
+
             val args = HashMap<String, Any?>()
             args["event_name"] = "on_remote_video_stats"
             args["data"] = HMSRtcStatsExtension.toDictionary(
@@ -1113,10 +1119,16 @@ class HmssdkFlutterPlugin :
             hmsTrack: HMSTrack?,
             hmsPeer: HMSPeer?
         ) {
-            if (hmsPeer == null || hmsTrack == null){
-                Log.e("onRemoteAudioStats err", "peer or track is null")
+            if (hmsPeer == null) {
+                Log.e("onRemoteAudioStats error", "Peer is null")
                 return
             }
+
+            if (hmsTrack == null) {
+                Log.e("onRemoteAudioStats error", "Video Track is null")
+                return
+            }
+
             val args = HashMap<String, Any?>()
             args["event_name"] = "on_remote_audio_stats"
             args["data"] = HMSRtcStatsExtension.toDictionary(
@@ -1137,10 +1149,16 @@ class HmssdkFlutterPlugin :
             hmsTrack: HMSTrack?,
             hmsPeer: HMSPeer?
         ) {
-            if (hmsPeer == null || hmsTrack == null){
-                Log.e("onLocalVideoStats err", "peer or track is null")
+            if (hmsPeer == null) {
+                Log.e("onLocalVideoStats error", "Peer is null")
                 return
             }
+
+            if (hmsTrack == null) {
+                Log.e("onLocalVideoStats error", "Video Track is null")
+                return
+            }
+
             val args = HashMap<String, Any?>()
             args["event_name"] = "on_local_video_stats"
             args["data"] = HMSRtcStatsExtension.toDictionary(
@@ -1161,10 +1179,16 @@ class HmssdkFlutterPlugin :
             hmsTrack: HMSTrack?,
             hmsPeer: HMSPeer?
         ) {
-            if (hmsPeer == null || hmsTrack == null){
-                Log.e("onLocalAudioStats err", "peer or track is null")
+            if (hmsPeer == null) {
+                Log.e("onLocalAudioStats error", "Peer is null")
                 return
             }
+
+            if (hmsTrack == null) {
+                Log.e("onLocalAudioStats error", "Video Track is null")
+                return
+            }
+
             val args = HashMap<String, Any?>()
             args["event_name"] = "on_local_audio_stats"
             args["data"] = HMSRtcStatsExtension.toDictionary(

--- a/android/src/main/kotlin/live/hms/hmssdk_flutter/views/HMSVideoView.kt
+++ b/android/src/main/kotlin/live/hms/hmssdk_flutter/views/HMSVideoView.kt
@@ -1,6 +1,7 @@
 package live.hms.hmssdk_flutter.views
 
 import android.content.Context
+import android.util.Log
 import android.view.LayoutInflater
 import android.widget.FrameLayout
 import live.hms.hmssdk_flutter.R
@@ -41,6 +42,9 @@ class HMSVideoView(
         super.onAttachedToWindow()
         if(track != null){
             hmsVideoView.addTrack(track)
+        }
+        else{
+            Log.e("HMSVideoView Error", "track is null, cannot attach null track")
         }
     }
 

--- a/android/src/main/kotlin/live/hms/hmssdk_flutter/views/HMSVideoView.kt
+++ b/android/src/main/kotlin/live/hms/hmssdk_flutter/views/HMSVideoView.kt
@@ -12,7 +12,7 @@ class HMSVideoView(
     context: Context,
     setMirror: Boolean,
     scaleType: Int? = RendererCommon.ScalingType.SCALE_ASPECT_FIT.ordinal,
-    private val track: HMSVideoTrack,
+    private val track: HMSVideoTrack?,
     disableAutoSimulcastLayerSelect: Boolean
 ) : FrameLayout(context, null) {
 
@@ -39,7 +39,9 @@ class HMSVideoView(
 
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
-        hmsVideoView.addTrack(track)
+        if(track != null){
+            hmsVideoView.addTrack(track)
+        }
     }
 
     override fun onDetachedFromWindow() {

--- a/ios/Classes/SwiftHmssdkFlutterPlugin.swift
+++ b/ios/Classes/SwiftHmssdkFlutterPlugin.swift
@@ -1151,5 +1151,14 @@ public class SwiftHmssdkFlutterPlugin: NSObject, FlutterPlugin, HMSUpdateListene
             }
         }
     }
-
+    
+    func sendCustomError(_ errorDict: [String: Any]) {
+        
+        let data = [
+            "event_name": "on_error",
+            "data": errorDict
+        ] as [String: Any]
+        
+        eventSink?(data)
+    }
 }

--- a/ios/Classes/Views/HMSFlutterPlatformView.swift
+++ b/ios/Classes/Views/HMSFlutterPlatformView.swift
@@ -15,7 +15,7 @@ class HMSFlutterPlatformView: NSObject, FlutterPlatformView {
     private let videoContentMode: UIView.ContentMode
     private let mirror: Bool
     private let disableAutoSimulcastLayerSelect: Bool
-    private let videoTrack: HMSVideoTrack
+    private let videoTrack: HMSVideoTrack?
     private var videoView: HMSVideoView?
 
     init(frame: CGRect,
@@ -23,7 +23,7 @@ class HMSFlutterPlatformView: NSObject, FlutterPlatformView {
         videoContentMode: UIView.ContentMode,
         mirror: Bool,
         disableAutoSimulcastLayerSelect: Bool,
-        videoTrack: HMSVideoTrack) {
+        videoTrack: HMSVideoTrack?) {
 
         self.frame = frame
         self.viewIdentifier = viewIdentifier
@@ -45,7 +45,14 @@ class HMSFlutterPlatformView: NSObject, FlutterPlatformView {
         videoView?.videoContentMode = videoContentMode
         videoView?.mirror = mirror
         videoView?.disableAutoSimulcastLayerSelect = disableAutoSimulcastLayerSelect
-        videoView?.setVideoTrack(videoTrack)
+        
+        if let track = videoTrack {
+            videoView?.setVideoTrack(track)
+        } else {
+            let errorMsg = "\(#function) Could not find video track to attach to Video View"
+            print(errorMsg)
+        }
+        
         return videoView!
     }
 

--- a/ios/Classes/Views/HMSFlutterPlatformViewFactory.swift
+++ b/ios/Classes/Views/HMSFlutterPlatformViewFactory.swift
@@ -26,7 +26,7 @@ class HMSFlutterPlatformViewFactory: NSObject, FlutterPlatformViewFactory {
                                       viewIdentifier: viewId,
                                       videoContentMode: getMode(from: arguments),
                                       mirror: getMirror(from: arguments),
-                                      disableAutoSimulcastLayerSelect: (getDisableAutoSimulcastLayerSelect(arguments)),
+                                      disableAutoSimulcastLayerSelect: getDisableAutoSimulcastLayerSelect(arguments),
                                       videoTrack: getVideoTrack(from: arguments))
     }
 
@@ -70,14 +70,32 @@ class HMSFlutterPlatformViewFactory: NSObject, FlutterPlatformViewFactory {
         }
     }
 
-    private func getVideoTrack(from arguments: [String: AnyObject]) -> HMSVideoTrack {
+    private func getVideoTrack(from arguments: [String: AnyObject]) -> HMSVideoTrack? {
 
-        let trackID = arguments["track_id"] as? String ?? ""
-
-        if let videoTrack = HMSUtilities.getVideoTrack(for: trackID, in: plugin.hmsSDK!.room!) {
-            return videoTrack
+        guard let trackID = arguments["track_id"] as? String
+        else {
+            let errorMsg = "\(#function) Could not find track_id in arguments: \(arguments)"
+            plugin.sendCustomError(HMSErrorExtension.getError(errorMsg))
+            print(errorMsg)
+            return nil
+        }
+        
+        guard let room = plugin.hmsSDK?.room
+        else {
+            let errorMsg = "\(#function) Could not find room for trackID: \(trackID)"
+            plugin.sendCustomError(HMSErrorExtension.getError(errorMsg))
+            print(errorMsg)
+            return nil
+        }
+        
+        guard let videoTrack = HMSUtilities.getVideoTrack(for: trackID, in: room)
+        else {
+            let errorMsg = "\(#function) Could not find video track in room with trackID: \(trackID)"
+            plugin.sendCustomError(HMSErrorExtension.getError(errorMsg))
+            print(errorMsg)
+            return nil
         }
 
-        return plugin.hmsSDK!.localPeer!.videoTrack!
+        return videoTrack
     }
 }


### PR DESCRIPTION
Fixes:

- Sends `onHMSError` if the track is null inside `HMSVideoView`
- Refactored peer and track checks for RTCStats