### PR TITLE
removed varying background colors on PIP window

### DIFF
--- a/example/lib/meeting/meeting_store.dart
+++ b/example/lib/meeting/meeting_store.dart
@@ -1432,7 +1432,7 @@ class MeetingStore extends ChangeNotifier
             aspectRatio: ratio,
             alternativeText: alternativeText,
             scaleType: ScaleType.SCALE_ASPECT_FILL,
-            backgroundColor: Utilities.getBackgroundColour(alternativeText));
+            backgroundColor: Color(0xFF6554C0));
         currentPIPtrack = track;
       }
     }
@@ -1446,7 +1446,7 @@ class MeetingStore extends ChangeNotifier
         HMSIOSPIPController.changeText(
             text: text,
             aspectRatio: ratio,
-            backgroundColor: Utilities.getBackgroundColour(text));
+            backgroundColor: Color(0xFF6554C0));
         currentPIPtrack = null;
       }
     }


### PR DESCRIPTION
Using only a single - app's default - background colour when the video track is muted in iOS PIP windows