### PR TITLE
Fix degrade icon overlap with more options icon

### DIFF
--- a/example/lib/common/widgets/degrade_tile.dart
+++ b/example/lib/common/widgets/degrade_tile.dart
@@ -11,13 +11,14 @@ import 'package:hmssdk_flutter_example/model/peer_track_node.dart';
 
 class DegradeTile extends StatefulWidget {
   final double itemHeight;
-
   final double itemWidth;
-  DegradeTile({
-    Key? key,
-    this.itemHeight = 200,
-    this.itemWidth = 200,
-  }) : super(key: key);
+  final bool isOneToOne;
+  DegradeTile(
+      {Key? key,
+      this.itemHeight = 200,
+      this.itemWidth = 200,
+      this.isOneToOne = false})
+      : super(key: key);
 
   @override
   State<DegradeTile> createState() => _DegradeTileState();
@@ -29,7 +30,7 @@ class _DegradeTileState extends State<DegradeTile> {
     return Selector<PeerTrackNode, bool>(
         builder: (_, data, __) {
           return Visibility(
-              visible: data,
+              visible: !data,
               child: Container(
                 height: widget.itemHeight + 110,
                 width: widget.itemWidth - 4,
@@ -39,22 +40,25 @@ class _DegradeTileState extends State<DegradeTile> {
                 child: Stack(
                   children: [
                     Padding(
-                      padding: const EdgeInsets.only(bottom: 45.0),
+                      padding: EdgeInsets.only(
+                          bottom: widget.isOneToOne ? 18 : 45.0),
                       child: Align(
-                        child: SubtitleText(
-                            text: "DEGRADED", textColor: Colors.white),
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            if (!widget.isOneToOne)
+                              Padding(
+                                padding: const EdgeInsets.only(right: 5),
+                                child: SvgPicture.asset(
+                                  'assets/icons/degrade.svg',
+                                ),
+                              ),
+                            SubtitleText(
+                                text: "DEGRADED", textColor: Colors.white),
+                          ],
+                        ),
                         alignment: Alignment.bottomCenter,
                       ),
-                    ),
-                    Positioned(
-                      child: Padding(
-                        padding: const EdgeInsets.fromLTRB(5, 5, 0, 0),
-                        child: SvgPicture.asset(
-                          'assets/icons/degrade.svg',
-                        ),
-                      ),
-                      bottom: 5.0,
-                      right: 5.0,
                     ),
                     AudioLevelAvatar()
                   ],

--- a/example/lib/common/widgets/degrade_tile.dart
+++ b/example/lib/common/widgets/degrade_tile.dart
@@ -30,7 +30,7 @@ class _DegradeTileState extends State<DegradeTile> {
     return Selector<PeerTrackNode, bool>(
         builder: (_, data, __) {
           return Visibility(
-              visible: !data,
+              visible: data,
               child: Container(
                 height: widget.itemHeight + 110,
                 width: widget.itemWidth - 4,

--- a/example/lib/common/widgets/peer_tile.dart
+++ b/example/lib/common/widgets/peer_tile.dart
@@ -89,6 +89,7 @@ class _PeerTileState extends State<PeerTile> {
                         label:
                             "fl_${context.read<PeerTrackNode>().peer.name}_degraded_tile",
                         child: DegradeTile(
+                          isOneToOne: widget.isOneToOne,
                           itemHeight: widget.itemHeight,
                           itemWidth: widget.itemWidth,
                         ),


### PR DESCRIPTION
# Description

Fixed the degrade icon overlap with three dots icon

Fixes:
- #1198 
---

### Pre-launch Checklist

- [x] The [Documentation] is updated accordingly, or this PR doesn't require it.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I added new tests to check the change I am making, or this PR is test-exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Documentation]: https://www.100ms.live/docs
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
