### PR TITLE
1141/removed static variable

### DIFF
--- a/android/src/main/kotlin/live/hms/hmssdk_flutter/views/HMSVideoView.kt
+++ b/android/src/main/kotlin/live/hms/hmssdk_flutter/views/HMSVideoView.kt
@@ -10,19 +10,20 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.FrameLayout
-import live.hms.hmssdk_flutter.HmssdkFlutterPlugin
 import live.hms.hmssdk_flutter.R
 import live.hms.video.media.tracks.HMSVideoTrack
 import live.hms.videoview.HMSVideoView
 import org.webrtc.RendererCommon
 import java.io.ByteArrayOutputStream
+import io.flutter.plugin.common.MethodChannel.Result
 
 class HMSVideoView(
     context: Context,
     private val setMirror: Boolean,
     private val scaleType: Int? = RendererCommon.ScalingType.SCALE_ASPECT_FIT.ordinal,
     private val track: HMSVideoTrack?,
-    private val disableAutoSimulcastLayerSelect: Boolean
+    private val disableAutoSimulcastLayerSelect: Boolean,
+    private val hmsVideoViewResult: Result?
 ) : FrameLayout(context, null) {
 
     private var hmsVideoView: HMSVideoView? = null
@@ -66,14 +67,10 @@ class HMSVideoView(
                     byteArray = stream.toByteArray()
                     bitmap.recycle()
                     val data = Base64.encodeToString(byteArray, Base64.DEFAULT)
-                    if (HmssdkFlutterPlugin.hmssdkFlutterPlugin != null) {
-                        if (HmssdkFlutterPlugin.hmssdkFlutterPlugin?.hmsVideoViewResult != null) {
-                            HmssdkFlutterPlugin.hmssdkFlutterPlugin?.hmsVideoViewResult?.success(data)
-                        } else {
-                            Log.e("Receiver error", "hmsVideoViewResult is null")
-                        }
+                    if (hmsVideoViewResult != null) {
+                        hmsVideoViewResult.success(data)
                     } else {
-                        Log.e("Receiver error", "hmssdkFlutterPlugin is null")
+                        Log.e("Receiver error", "hmsVideoViewResult is null")
                     }
                 }
             })

--- a/android/src/main/kotlin/live/hms/hmssdk_flutter/views/HMSVideoViewFactory.kt
+++ b/android/src/main/kotlin/live/hms/hmssdk_flutter/views/HMSVideoViewFactory.kt
@@ -12,6 +12,7 @@ import live.hms.hmssdk_flutter.HmssdkFlutterPlugin
 import live.hms.video.error.HMSException
 import live.hms.video.media.tracks.HMSVideoTrack
 import live.hms.video.utils.HmsUtilities
+import io.flutter.plugin.common.MethodChannel.Result
 
 class HMSVideoViewWidget(
     private val context: Context,
@@ -21,14 +22,15 @@ class HMSVideoViewWidget(
     setMirror: Boolean,
     scaleType: Int?,
     private val matchParent: Boolean? = true,
-    disableAutoSimulcastLayerSelect: Boolean
+    disableAutoSimulcastLayerSelect: Boolean,
+    hmsVideoViewResult: Result?
 ) : PlatformView {
 
     private var hmsVideoView: HMSVideoView? = null
 
     init {
         if (hmsVideoView == null) {
-            hmsVideoView = HMSVideoView(context, setMirror, scaleType, track, disableAutoSimulcastLayerSelect)
+            hmsVideoView = HMSVideoView(context, setMirror, scaleType, track, disableAutoSimulcastLayerSelect,hmsVideoViewResult)
         }
     }
 
@@ -96,6 +98,6 @@ class HMSVideoViewFactory(private val plugin: HmssdkFlutterPlugin) :
         }
         val disableAutoSimulcastLayerSelect = args!!["disable_auto_simulcast_layer_select"] as? Boolean ?: false
 
-        return HMSVideoViewWidget(requireNotNull(context), viewId, creationParams, track, setMirror!!, scaleType, matchParent, disableAutoSimulcastLayerSelect)
+        return HMSVideoViewWidget(requireNotNull(context), viewId, creationParams, track, setMirror!!, scaleType, matchParent, disableAutoSimulcastLayerSelect,plugin.hmsVideoViewResult)
     }
 }

--- a/example/android/app/src/main/kotlin/live/hms/flutter/MainActivity.kt
+++ b/example/android/app/src/main/kotlin/live/hms/flutter/MainActivity.kt
@@ -6,7 +6,6 @@ import android.content.res.Configuration
 import android.util.Log
 import io.flutter.embedding.android.FlutterActivity
 import live.hms.hmssdk_flutter.Constants
-import live.hms.hmssdk_flutter.HmssdkFlutterPlugin
 import live.hms.hmssdk_flutter.methods.HMSPipAction
 
 class MainActivity : FlutterActivity() {
@@ -15,11 +14,14 @@ class MainActivity : FlutterActivity() {
         super.onActivityResult(requestCode, resultCode, data)
 
         if (requestCode == Constants.SCREEN_SHARE_INTENT_REQUEST_CODE && resultCode == Activity.RESULT_OK) {
-            HmssdkFlutterPlugin.hmssdkFlutterPlugin?.requestScreenShare(data)
+            data?.action = "ACTIVITY_RECEIVER"
+            activity.sendBroadcast(data?.putExtra("method_name","REQUEST_SCREEN_SHARE"))
         }
 
         if (requestCode == Constants.AUDIO_SHARE_INTENT_REQUEST_CODE && resultCode == Activity.RESULT_OK) {
-            HmssdkFlutterPlugin.hmssdkFlutterPlugin?.requestAudioShare(data)
+            data?.action = "ACTIVITY_RECEIVER"
+            activity.sendBroadcast(data?.putExtra("method_name","REQUEST_AUDIO_SHARE"))
+
         }
     }
 


### PR DESCRIPTION
# Description

`hmssdkFlutterPlugin` is now non-static variable on android

Fixes:
- #1141 

---

## Additional context

- Things affected by this change and need to be tested:

   -  Screen share flow on Android 
   - Audio share flow on Android
   - Callkit integration when the application is in the terminated state

### Pre-launch Checklist

- [X] The [Documentation] is updated accordingly, or this PR doesn't require it.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I added new tests to check the change I am making, or this PR is test-exempt.
- [X] All existing and new tests are passing.

<!-- Links -->
[Documentation]: https://www.100ms.live/docs
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
