### PR TITLE
Added destroy pip on clear room state

### DIFF
--- a/example/lib/meeting/meeting_store.dart
+++ b/example/lib/meeting/meeting_store.dart
@@ -992,6 +992,11 @@ class MeetingStore extends ChangeNotifier
     writeLogs(_logsDump);
     hlsVideoController?.dispose(forceDispose: true);
     hlsVideoController = null;
+    if (Platform.isAndroid) {
+      HMSAndroidPIPController.destroy();
+    } else if (Platform.isIOS) {
+      HMSIOSPIPController.destroy();
+    }
     _hmsSDKInteractor.removeHMSLogger();
     _hmsSDKInteractor.destroy();
     peerTracks.clear();
@@ -1492,12 +1497,6 @@ class MeetingStore extends ChangeNotifier
             text: text, aspectRatio: ratio, backgroundColor: Colors.black);
         currentPIPtrack = null;
       }
-    }
-  }
-
-  void destroyPIPSetupOnIOS() {
-    if (Platform.isIOS) {
-      HMSIOSPIPController.destroy();
     }
   }
 


### PR DESCRIPTION
# Description

Added destroy pip on clear room state which was causing the pip to stay while in preview and home screen if user has joined the call even once.

### Pre-launch Checklist

- [X] The [Documentation] is updated accordingly, or this PR doesn't require it.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I added new tests to check the change I am making, or this PR is test-exempt.
- [X] All existing and new tests are passing.

<!-- Links -->
[Documentation]: https://www.100ms.live/docs
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
