### PR TITLE
Reverted the hmsVideoViewResult changes

### DIFF
--- a/android/src/main/kotlin/live/hms/hmssdk_flutter/views/HMSVideoView.kt
+++ b/android/src/main/kotlin/live/hms/hmssdk_flutter/views/HMSVideoView.kt
@@ -16,6 +16,7 @@ import live.hms.videoview.HMSVideoView
 import org.webrtc.RendererCommon
 import java.io.ByteArrayOutputStream
 import io.flutter.plugin.common.MethodChannel.Result
+import live.hms.hmssdk_flutter.HmssdkFlutterPlugin
 
 class HMSVideoView(
     context: Context,
@@ -23,7 +24,7 @@ class HMSVideoView(
     private val scaleType: Int? = RendererCommon.ScalingType.SCALE_ASPECT_FIT.ordinal,
     private val track: HMSVideoTrack?,
     private val disableAutoSimulcastLayerSelect: Boolean,
-    private val hmsVideoViewResult: Result?
+    private val hmssdkFlutterPlugin: HmssdkFlutterPlugin?
 ) : FrameLayout(context, null) {
 
     private var hmsVideoView: HMSVideoView? = null
@@ -67,10 +68,15 @@ class HMSVideoView(
                     byteArray = stream.toByteArray()
                     bitmap.recycle()
                     val data = Base64.encodeToString(byteArray, Base64.DEFAULT)
-                    if (hmsVideoViewResult != null) {
-                        hmsVideoViewResult.success(data)
-                    } else {
-                        Log.e("Receiver error", "hmsVideoViewResult is null")
+                    if(hmssdkFlutterPlugin != null){
+                        if (hmssdkFlutterPlugin.hmsVideoViewResult != null) {
+                            hmssdkFlutterPlugin.hmsVideoViewResult?.success(data)
+                        } else {
+                            Log.e("Receiver error", "hmsVideoViewResult is null")
+                        }
+                    }
+                    else{
+                        Log.e("Receiver error", "hmssdkFlutterPlugin is null")
                     }
                 }
             })

--- a/android/src/main/kotlin/live/hms/hmssdk_flutter/views/HMSVideoViewFactory.kt
+++ b/android/src/main/kotlin/live/hms/hmssdk_flutter/views/HMSVideoViewFactory.kt
@@ -23,14 +23,14 @@ class HMSVideoViewWidget(
     scaleType: Int?,
     private val matchParent: Boolean? = true,
     disableAutoSimulcastLayerSelect: Boolean,
-    hmsVideoViewResult: Result?
+    hmssdkFlutterPlugin: HmssdkFlutterPlugin?
 ) : PlatformView {
 
     private var hmsVideoView: HMSVideoView? = null
 
     init {
         if (hmsVideoView == null) {
-            hmsVideoView = HMSVideoView(context, setMirror, scaleType, track, disableAutoSimulcastLayerSelect,hmsVideoViewResult)
+            hmsVideoView = HMSVideoView(context, setMirror, scaleType, track, disableAutoSimulcastLayerSelect,hmssdkFlutterPlugin)
         }
     }
 
@@ -98,6 +98,6 @@ class HMSVideoViewFactory(private val plugin: HmssdkFlutterPlugin) :
         }
         val disableAutoSimulcastLayerSelect = args!!["disable_auto_simulcast_layer_select"] as? Boolean ?: false
 
-        return HMSVideoViewWidget(requireNotNull(context), viewId, creationParams, track, setMirror!!, scaleType, matchParent, disableAutoSimulcastLayerSelect,plugin.hmsVideoViewResult)
+        return HMSVideoViewWidget(requireNotNull(context), viewId, creationParams, track, setMirror!!, scaleType, matchParent, disableAutoSimulcastLayerSelect,plugin)
     }
 }


### PR DESCRIPTION
# Description

- Fixed an issue where `hmsVideoViewResult` was coming `null` causing `captureSnapshot` method to fail in android

## Additional context

Things affected and need to be tested:
- `captureSnapshot` in android

### Pre-launch Checklist

- [X] The [Documentation] is updated accordingly, or this PR doesn't require it.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I added new tests to check the change I am making, or this PR is test-exempt.
- [X] All existing and new tests are passing.

<!-- Links -->
[Documentation]: https://www.100ms.live/docs
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
