### PR TITLE
Fixed active speaker border color to default

### DIFF
--- a/example/lib/common/peer_widgets/tile_border.dart
+++ b/example/lib/common/peer_widgets/tile_border.dart
@@ -30,7 +30,7 @@ class TileBorder extends StatelessWidget {
             decoration: BoxDecoration(
               border: Border.all(
                   color: (audioLevel != -1)
-                      ? Utilities.getBackgroundColour(name)
+                      ? hmsdefaultColor
                       : themeBottomSheetColor,
                   width: (audioLevel != -1) ? 4.0 : 0.0),
               borderRadius: BorderRadius.all(Radius.circular(10)),


### PR DESCRIPTION
# Description

Fixed active speaker tile border color to default.

### Pre-launch Checklist

- [X] The [Documentation] is updated accordingly, or this PR doesn't require it.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I added new tests to check the change I am making, or this PR is test-exempt.
- [X] All existing and new tests are passing.

<!-- Links -->
[Documentation]: https://www.100ms.live/docs
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
