### PR TITLE
Release 1.7.1: Added support to Not mute local peer when incoming phone call is ringing

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,19 +1,23 @@
 version: 0.1
 cli:
-  version: 1.11.0
+  version: 1.11.1
 plugins:
   sources:
     - id: trunk
-      ref: v0.0.17
+      ref: v0.0.21
       uri: https://github.com/trunk-io/plugins
 lint:
   enabled:
+    - checkov@2.3.307
+    - osv-scanner@1.3.4
+    - trivy@0.42.1
+    - trufflehog@3.41.1
     - oxipng@8.0.0
     - yamllint@1.32.0
     - markdownlint@0.35.0
     - prettier@2.8.8
     - git-diff-check
-    - shfmt@3.5.0
+    - shfmt@3.6.0
     - shellcheck@0.9.0
     - gitleaks@8.17.0
     - svgo@3.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 1.7.1 - 2023-06-30
+
+### Added
+
+- Added phoneCallState property in `HMSAudioTrackSetting`
+
+  The `phoneCallState` property can be used to set the microphone state when you receive a phone call.
+
+  Read more about the `phoneCallState` property [here](https://www.100ms.live/docs/flutter/v2/how-to-guides/interact-with-room/track/set-track-settings#phonecallstate-android-only).
+
+Updated to Android SDK 2.6.8 & iOS SDK 0.9.5
+
+**Full Changelog**: [1.7.0...1.7.1](https://github.com/100mslive/100ms-flutter/compare/1.7.0...1.7.1)
+
 ## 1.7.0 - 2023-06-20
 
 ### Breaking

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -24,6 +24,10 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+
+    <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
+
+    <uses-permission android:name="android.permission.READ_PHONE_NUMBERS" />
     
     <application>
         <activity android:name=".SecondActivity"></activity>

--- a/android/src/main/kotlin/live/hms/hmssdk_flutter/HMSTrackSettingsExtension.kt
+++ b/android/src/main/kotlin/live/hms/hmssdk_flutter/HMSTrackSettingsExtension.kt
@@ -3,6 +3,7 @@ package live.hms.hmssdk_flutter
 import live.hms.video.media.settings.HMSAudioTrackSettings
 import live.hms.video.media.settings.HMSTrackSettings
 import live.hms.video.media.settings.HMSVideoTrackSettings
+import live.hms.video.media.settings.PhoneCallState
 import live.hms.video.sdk.HMSSDK
 
 class HMSTrackSettingsExtension {
@@ -25,28 +26,27 @@ class HMSTrackSettingsExtension {
 
         fun setTrackSettings(hmsAudioTrackHashMap: HashMap<String, Any?>?, hmsVideoTrackHashMap: HashMap<String, Any?>?): HMSTrackSettings {
             var hmsAudioTrackSettings = HMSAudioTrackSettings.Builder()
-            if (hmsAudioTrackHashMap != null) {
+
+            hmsAudioTrackSettings.setUseHardwareAcousticEchoCanceler(false)
+            hmsAudioTrackSettings.setPhoneCallMuteState(PhoneCallState.DISABLE_MUTE_ON_VOIP_PHONE_CALL_RING)
+
+            hmsAudioTrackHashMap?.let { audioHashMap ->
+
+                val initialState = HMSTrackInitStateExtension.getHMSTrackInitStatefromValue(audioHashMap["track_initial_state"] as String)
+                hmsAudioTrackSettings = hmsAudioTrackSettings.initialState(initialState)
+
                 val useHardwareAcousticEchoCanceler =
-                    hmsAudioTrackHashMap["user_hardware_acoustic_echo_canceler"] as Boolean?
-
-                val initialState = HMSTrackInitStateExtension.getHMSTrackInitStatefromValue(hmsAudioTrackHashMap["track_initial_state"] as String)
-
-                /**
-                 * Setting hardware acoustic echo canceler to false by default
-                 * If no value is passed from flutter
-                 */
-                hmsAudioTrackSettings = if (useHardwareAcousticEchoCanceler != null) {
-                    hmsAudioTrackSettings.setUseHardwareAcousticEchoCanceler(
-                        useHardwareAcousticEchoCanceler,
-                    )
-                } else {
-                    hmsAudioTrackSettings.setUseHardwareAcousticEchoCanceler(
-                        false,
-                    )
+                    audioHashMap["user_hardware_acoustic_echo_canceler"] as Boolean?
+                useHardwareAcousticEchoCanceler?.let { useHardware ->
+                    hmsAudioTrackSettings.setUseHardwareAcousticEchoCanceler(useHardware)
                 }
 
-                if (initialState != null) {
-                    hmsAudioTrackSettings = hmsAudioTrackSettings.initialState(initialState)
+                val phoneCallMuteState = audioHashMap["phone_call_mute_state"] as? String
+                phoneCallMuteState?.let {
+                    when (it) {
+                        "ENABLE_MUTE_ON_PHONE_CALL_RING" -> hmsAudioTrackSettings.setPhoneCallMuteState(PhoneCallState.ENABLE_MUTE_ON_PHONE_CALL_RING)
+                        else -> hmsAudioTrackSettings.setPhoneCallMuteState(PhoneCallState.DISABLE_MUTE_ON_VOIP_PHONE_CALL_RING)
+                    }
                 }
             }
 

--- a/android/src/main/kotlin/live/hms/hmssdk_flutter/HMSTrackSettingsExtension.kt
+++ b/android/src/main/kotlin/live/hms/hmssdk_flutter/HMSTrackSettingsExtension.kt
@@ -42,8 +42,8 @@ class HMSTrackSettingsExtension {
                 }
 
                 val phoneCallMuteState = audioHashMap["phone_call_mute_state"] as? String
-                phoneCallMuteState?.let {
-                    when (it) {
+                phoneCallMuteState?.let { callMuteState ->
+                    when (callMuteState) {
                         "ENABLE_MUTE_ON_PHONE_CALL_RING" -> hmsAudioTrackSettings.setPhoneCallMuteState(PhoneCallState.ENABLE_MUTE_ON_PHONE_CALL_RING)
                         else -> hmsAudioTrackSettings.setPhoneCallMuteState(PhoneCallState.DISABLE_MUTE_ON_VOIP_PHONE_CALL_RING)
                     }

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -22,6 +22,8 @@
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="com.google.android.gms.permission.AD_ID"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
+    <uses-permission android:name="android.permission.READ_PHONE_NUMBERS" />
     
    <application
         android:label="100ms Video Calling Streaming"

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -189,7 +189,7 @@ PODS:
   - HMSSDK (0.9.5):
     - HMSAnalyticsSDK (= 0.0.2)
     - HMSWebRTC (= 1.0.5116)
-  - hmssdk_flutter (1.7.0):
+  - hmssdk_flutter (1.7.1):
     - Flutter
     - HMSBroadcastExtensionSDK (= 0.0.9)
     - HMSHLSPlayerSDK (= 0.0.2)
@@ -355,7 +355,7 @@ SPEC CHECKSUMS:
   HMSBroadcastExtensionSDK: d80fe325f6c928bd8e5176290b5a4b7ae15d6fbb
   HMSHLSPlayerSDK: 6a54ad4d12f3dc2270d1ecd24019d71282a4f6a3
   HMSSDK: 81804295a3c5ec6016c0966f2053d7f5f51ccc26
-  hmssdk_flutter: b57a9cc476ec04062d3189935893f5b0b22ab617
+  hmssdk_flutter: aaba93b8324a1a4b735b7d0cc94d171987c77f5b
   HMSWebRTC: ae54e9dd91b869051b283b43b14f57d43b7bf8e1
   image_gallery_saver: cb43cc43141711190510e92c460eb1655cd343cb
   MTBBarcodeScanner: f453b33c4b7dfe545d8c6484ed744d55671788cb

--- a/example/lib/common/util/utility_function.dart
+++ b/example/lib/common/util/utility_function.dart
@@ -107,6 +107,8 @@ class Utilities {
     await Permission.camera.request();
     await Permission.microphone.request();
     await Permission.bluetoothConnect.request();
+    await Permission.phone.request();
+    
     // storage permission is required to save Snapshot to device gallery.
     await Permission.storage.request();
 

--- a/example/lib/common/util/utility_function.dart
+++ b/example/lib/common/util/utility_function.dart
@@ -108,7 +108,7 @@ class Utilities {
     await Permission.microphone.request();
     await Permission.bluetoothConnect.request();
     await Permission.phone.request();
-    
+
     // storage permission is required to save Snapshot to device gallery.
     await Permission.storage.request();
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -374,7 +374,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.7.0"
+    version: "1.7.1"
   http:
     dependency: "direct main"
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,7 +4,7 @@ description: Demonstrates how to use the hmssdk_flutter plugin.
 # The following line prevents the package from being accidentally published to
 # pub.dev using `pub publish`. This is preferred for private packages.
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
-version: 1.6.1
+version: 1.7.1
 environment:
   sdk: ">=2.16.0 <4.0.0"
 

--- a/ios/Classes/SwiftHmssdkFlutterPlugin.swift
+++ b/ios/Classes/SwiftHmssdkFlutterPlugin.swift
@@ -1056,7 +1056,7 @@ public class SwiftHmssdkFlutterPlugin: NSObject, FlutterPlugin, HMSUpdateListene
 
         logsBuffer.append(message)
         logsDump.append(message)
-        
+
         if logsBuffer.count >= 512 {
             var args = [String: Any]()
             args["event_name"] = "on_logs_update"

--- a/lib/assets/sdk-versions.json
+++ b/lib/assets/sdk-versions.json
@@ -1,7 +1,7 @@
 {
-  "flutter": "1.7.0",
+  "flutter": "1.7.1",
   "ios": "0.9.5",
   "iOSBroadcastExtension": "0.0.9",
   "iOSHLSPlayerSDK": "0.0.2",
-  "android": "2.6.7"
+  "android": "2.6.8"
 }

--- a/lib/src/enum/hms_phone_call_state.dart
+++ b/lib/src/enum/hms_phone_call_state.dart
@@ -1,5 +1,9 @@
 enum HMSAndroidPhoneCallState {
+
+  // To keep the microphone unmuted while receiving a phone call
   DISABLE_MUTE_ON_VOIP_PHONE_CALL_RING,
+
+  // To mute the microphone while receiving a phone call
   ENABLE_MUTE_ON_PHONE_CALL_RING,
 }
 

--- a/lib/src/enum/hms_phone_call_state.dart
+++ b/lib/src/enum/hms_phone_call_state.dart
@@ -1,0 +1,25 @@
+enum HMSAndroidPhoneCallState {
+  DISABLE_MUTE_ON_VOIP_PHONE_CALL_RING,
+  ENABLE_MUTE_ON_PHONE_CALL_RING,
+}
+
+extension HMSAndroidPhoneCallStateValue on HMSAndroidPhoneCallState {
+  static HMSAndroidPhoneCallState getHMSPhoneCallStateFromName(String state) {
+    switch (state) {
+      case 'ENABLE_MUTE_ON_PHONE_CALL_RING':
+        return HMSAndroidPhoneCallState.ENABLE_MUTE_ON_PHONE_CALL_RING;
+      default:
+        return HMSAndroidPhoneCallState.DISABLE_MUTE_ON_VOIP_PHONE_CALL_RING;
+    }
+  }
+
+  static String getValuefromHMSPhoneCallState(
+      HMSAndroidPhoneCallState? phoneCallState) {
+    switch (phoneCallState) {
+      case HMSAndroidPhoneCallState.ENABLE_MUTE_ON_PHONE_CALL_RING:
+        return 'ENABLE_MUTE_ON_PHONE_CALL_RING';
+      default:
+        return 'DISABLE_MUTE_ON_VOIP_PHONE_CALL_RING';
+    }
+  }
+}

--- a/lib/src/enum/hms_phone_call_state.dart
+++ b/lib/src/enum/hms_phone_call_state.dart
@@ -1,5 +1,4 @@
 enum HMSAndroidPhoneCallState {
-
   // To keep the microphone unmuted while receiving a phone call
   DISABLE_MUTE_ON_VOIP_PHONE_CALL_RING,
 

--- a/lib/src/model/hls_player/hms_hls_player_controller.dart
+++ b/lib/src/model/hls_player/hms_hls_player_controller.dart
@@ -49,7 +49,7 @@ class HMSHLSPlayerController {
   }
 
   /// Resumes the paused HLS playback.
-  /// Refer [Resume HLS Playback](https://www.100ms.live/docs/flutter/v2/how-to-guides/record-and-live-stream/hls-player#how-to-pause-and-resume-the-playback) 
+  /// Refer [Resume HLS Playback](https://www.100ms.live/docs/flutter/v2/how-to-guides/record-and-live-stream/hls-player#how-to-pause-and-resume-the-playback)
   static Future<void> resume() async {
     await PlatformService.invokeMethod(PlatformMethod.resume);
   }

--- a/lib/src/model/hms_audio_track_setting.dart
+++ b/lib/src/model/hms_audio_track_setting.dart
@@ -1,6 +1,7 @@
 // Project imports:
 import 'package:hmssdk_flutter/hmssdk_flutter.dart';
 import 'package:hmssdk_flutter/src/model/hms_audio_node.dart';
+import 'package:hmssdk_flutter/src/enum/hms_phone_call_state.dart';
 
 ///100ms HMSAudioTrackSetting
 ///
@@ -27,11 +28,15 @@ class HMSAudioTrackSetting {
   ///Refer: Read more about audio mode [here](https://www.100ms.live/docs/flutter/v2/how-to-guides/configure-your-device/microphone/music-mode)
   final HMSAudioMode? audioMode;
 
+  final HMSAndroidPhoneCallState phoneCallState;
+
   HMSAudioTrackSetting(
       {this.useHardwareAcousticEchoCanceler,
       this.audioSource,
       this.trackInitialState = HMSTrackInitState.UNMUTED,
-      this.audioMode});
+      this.audioMode,
+      this.phoneCallState =
+          HMSAndroidPhoneCallState.DISABLE_MUTE_ON_VOIP_PHONE_CALL_RING});
 
   factory HMSAudioTrackSetting.fromMap(Map map) {
     List<HMSAudioNode> nodeList = [];
@@ -52,6 +57,16 @@ class HMSAudioTrackSetting {
     if ((map.containsKey("audio_mode")) && (map["audio_mode"] != null)) {
       audioMode = HMSAudioModeValues.getAudioModeFromName(map["audio_mode"]);
     }
+
+    HMSAndroidPhoneCallState phoneCallState =
+        HMSAndroidPhoneCallState.DISABLE_MUTE_ON_VOIP_PHONE_CALL_RING;
+    if (map.containsKey("phone_call_state")) {
+      if (map["phone_call_state"] != "DISABLE_MUTE_ON_VOIP_PHONE_CALL_RING") {
+        phoneCallState =
+            HMSAndroidPhoneCallState.ENABLE_MUTE_ON_PHONE_CALL_RING;
+      }
+    }
+
     return HMSAudioTrackSetting(
         useHardwareAcousticEchoCanceler:
             map['user_hardware_acoustic_echo_canceler'] ?? null,
@@ -60,7 +75,8 @@ class HMSAudioTrackSetting {
             ? HMSTrackInitStateValue.getHMSTrackInitStateFromName(
                 map['track_initial_state'])
             : HMSTrackInitState.UNMUTED,
-        audioMode: audioMode);
+        audioMode: audioMode,
+        phoneCallState: phoneCallState);
   }
 
   Map<String, dynamic> toMap() {
@@ -72,7 +88,10 @@ class HMSAudioTrackSetting {
               trackInitialState),
       'audio_mode': (audioMode != null)
           ? HMSAudioModeValues.getNameFromHMSAudioMode(audioMode!)
-          : null
+          : null,
+      'phone_call_state':
+          HMSAndroidPhoneCallStateValue.getValuefromHMSPhoneCallState(
+              phoneCallState)
     };
   }
 }

--- a/lib/src/model/hms_audio_track_setting.dart
+++ b/lib/src/model/hms_audio_track_setting.dart
@@ -28,6 +28,11 @@ class HMSAudioTrackSetting {
   ///Refer: Read more about audio mode [here](https://www.100ms.live/docs/flutter/v2/how-to-guides/configure-your-device/microphone/music-mode)
   final HMSAudioMode? audioMode;
 
+  ///[phoneCallState] property to set the state of microphone i.e mute/unmute on phone call ring
+  ///If set to `DISABLE_MUTE_ON_VOIP_PHONE_CALL_RING` then the microphone will not be muted on phone call ring
+  ///Similarly if set to `ENABLE_MUTE_ON_PHONE_CALL_RING` then the microphone will be muted on phone call ring
+  ///By default it's set to `DISABLE_MUTE_ON_VOIP_PHONE_CALL_RING`
+  ///Refer: Read more about phone call state [here](https://www.100ms.live/docs/flutter/v2/how-to-guides/interact-with-room/track/set-track-settings#phonecallstate-android-only)
   final HMSAndroidPhoneCallState phoneCallState;
 
   HMSAudioTrackSetting(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: hmssdk_flutter
 description: Add Real Time Audio & Video calls, Interactive Live Streaming & Recording, Chat, HLS, RTMP,  PiP, CallKit, VoIP, Video conferencing, Stream Player & WebRTC-based communications API
-version: 1.7.0
+version: 1.7.1
 homepage: https://www.100ms.live/
 repository: https://github.com/100mslive/100ms-flutter
 issue_tracker: https://github.com/100mslive/100ms-flutter/issues


### PR DESCRIPTION
# Description

- Added option to NOT mute when the phone is in ringing state. 
- By default, the local peer will not be muted when phone call is ringing. 

### Pre-launch Checklist

- [x] The [Documentation] is updated accordingly, or this PR doesn't require it.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I added new tests to check the change I am making, or this PR is test-exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Documentation]: https://www.100ms.live/docs
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
