### PR TITLE
Added bottom padding in grant permissions button

### DIFF
--- a/packages/hms_room_kit/lib/src/preview/preview_permissions.dart
+++ b/packages/hms_room_kit/lib/src/preview/preview_permissions.dart
@@ -81,7 +81,7 @@ class _PreviewPermissionsState extends State<PreviewPermissions> {
                 alignment: Alignment.bottomCenter,
                 child: Padding(
                   padding:
-                      const EdgeInsets.symmetric(horizontal: 8.0, vertical: 8),
+                      const EdgeInsets.fromLTRB(8,8,8,24),
                   child: SizedBox(
                     width: size.width - 40,
                     height: 48,


### PR DESCRIPTION
# Description

- Added bottom padding in grant permissions screen

### Pre-launch Checklist

- [X] The [Documentation] is updated accordingly, or this PR doesn't require it.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I added new tests to check the change I am making, or this PR is test-exempt.
- [X] All existing and new tests are passing.

<!-- Links -->
[Documentation]: https://www.100ms.live/docs
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
