### PR TITLE
Fix: edge to edge player based on stream size on iOS

### DIFF
--- a/packages/hmssdk_flutter/ios/Classes/HLSPlayer/HMSHLSStreamViewController.swift
+++ b/packages/hmssdk_flutter/ios/Classes/HLSPlayer/HMSHLSStreamViewController.swift
@@ -82,7 +82,15 @@ class HMSHLSStreamViewController: HMSHLSPlayerDelegate {
             return
         }
         hmssdkFlutterPlugin.hlsPlayerSink?(data)
-
     }
 
+    func onResolutionChanged(videoSize: CGSize) {
+        let playerView = hlsPlayer?.videoPlayerViewController(showsPlayerControls: false)
+        if videoSize.width >= videoSize.height {
+            playerView?.videoGravity = .resizeAspect
+        }
+        else {
+            playerView?.videoGravity = .resizeAspectFill
+        }
+    }
 }


### PR DESCRIPTION
# Description

- Fix: edge to edge player based on stream size on iOS

### Pre-launch Checklist

- [x] The [Documentation] is updated accordingly, or this PR doesn't require it.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I added new tests to check the change I am making, or this PR is test-exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Documentation]: https://www.100ms.live/docs
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
