### PR TITLE
Bug fix/flut 138 recording null fix

### DIFF
--- a/packages/hmssdk_flutter/android/src/main/kotlin/live/hms/hmssdk_flutter/HMSRtmpStreamingState.kt
+++ b/packages/hmssdk_flutter/android/src/main/kotlin/live/hms/hmssdk_flutter/HMSRtmpStreamingState.kt
@@ -12,7 +12,9 @@ class HMSStreamingState {
             map["running"] = hmsRtmpStreamingState.running
             map["error"] = HMSExceptionExtension.toDictionary(hmsRtmpStreamingState.error)
             if (hmsRtmpStreamingState.running) {
-                map["started_at"] = SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(hmsRtmpStreamingState.startedAt).toString()
+                hmsRtmpStreamingState.startedAt?.let {
+                    map["started_at"] = SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(hmsRtmpStreamingState.startedAt).toString()
+                }
             }
             return map
         }
@@ -23,7 +25,9 @@ class HMSStreamingState {
             map["running"] = hmsServerRecordingState.running
             map["error"] = HMSExceptionExtension.toDictionary(hmsServerRecordingState.error)
             if (hmsServerRecordingState.running) {
-                map["started_at"] = SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(hmsServerRecordingState.startedAt).toString()
+                hmsServerRecordingState.startedAt?.let {
+                    map["started_at"] = SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(hmsServerRecordingState.startedAt).toString()
+                }
             }
             return map
         }
@@ -34,7 +38,9 @@ class HMSStreamingState {
             map["running"] = hmsBrowserRecordingState.running
             map["error"] = HMSExceptionExtension.toDictionary(hmsBrowserRecordingState.error)
             if (hmsBrowserRecordingState.running) {
-                map["started_at"] = SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(hmsBrowserRecordingState.startedAt).toString()
+                hmsBrowserRecordingState.startedAt?.let {
+                    map["started_at"] = SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(hmsBrowserRecordingState.startedAt).toString()
+                }
             }
             map["initialising"] = hmsBrowserRecordingState.initialising
             return map
@@ -57,7 +63,9 @@ class HMSStreamingState {
             if (hmsHlsRecordingState == null)return null
             map["running"] = hmsHlsRecordingState.running
             if (hmsHlsRecordingState.running == true) {
-                map["started_at"] = SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(hmsHlsRecordingState.startedAt).toString()
+                hmsHlsRecordingState.startedAt?.let {
+                    map["started_at"] = SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(hmsHlsRecordingState.startedAt).toString()
+                }
             }
             return map
         }


### PR DESCRIPTION
# Description

- Fixed bug where `startedAt` property was causing a crash when passed null

### Pre-launch Checklist

- [X] The [Documentation] is updated accordingly, or this PR doesn't require it.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I added new tests to check the change I am making, or this PR is test-exempt.
- [X] All existing and new tests are passing.

<!-- Links -->
[Documentation]: https://www.100ms.live/docs
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
