### PR TITLE
Added error description in toast

### DIFF
--- a/packages/hms_room_kit/lib/src/common/utility_components.dart
+++ b/packages/hms_room_kit/lib/src/common/utility_components.dart
@@ -1087,7 +1087,7 @@ class UtilityComponents {
         color: HMSThemeColors.backgroundDefault.withOpacity(0.5),
         child: HMSDisconnectedToast(
           errorDescription:
-              "CODE: ${exception.code?.errorCode}, ${exception.message}",
+              "CODE: ${exception.code?.errorCode}, ${exception.description}",
           onLeavePressed: onLeavePressed,
         ));
   }


### PR DESCRIPTION
# Description

- Added `errorDescription` in error toast.

### Pre-launch Checklist

- [X] The [Documentation] is updated accordingly, or this PR doesn't require it.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I added new tests to check the change I am making, or this PR is test-exempt.
- [X] All existing and new tests are passing.

<!-- Links -->
[Documentation]: https://www.100ms.live/docs
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
