### PR TITLE
FLUT-148: Removed setVolume call on foreground callback

### DIFF
--- a/packages/hms_room_kit/lib/src/meeting/meeting_store.dart
+++ b/packages/hms_room_kit/lib/src/meeting/meeting_store.dart
@@ -2238,18 +2238,6 @@ class MeetingStore extends ChangeNotifier
         lastVideoStatus = false;
       }
 
-      List<HMSPeer>? peersList = await getPeers();
-
-      peersList?.forEach((element) {
-        if (!element.isLocal && (Platform.isAndroid)) {
-          (element.audioTrack as HMSRemoteAudioTrack?)?.setVolume(10.0);
-          element.auxiliaryTracks?.forEach((element) {
-            if (element.kind == HMSTrackKind.kHMSTrackKindAudio) {
-              (element as HMSRemoteAudioTrack?)?.setVolume(10.0);
-            }
-          });
-        }
-      });
     } else if (state == AppLifecycleState.paused) {
       HMSLocalPeer? localPeer = await getLocalPeer();
       if (localPeer != null &&

--- a/packages/hmssdk_flutter/example/ExampleAppChangelog.txt
+++ b/packages/hmssdk_flutter/example/ExampleAppChangelog.txt
@@ -9,6 +9,9 @@ Upgrade Android SDK to fix Auto simulcast issue in HmsVideoView
 Remove default usage of Software Echo Cancellation
 - https://100ms.atlassian.net/browse/FLUT-146
 
+Post call interruption fix
+- https://100ms.atlassian.net/browse/FLUT-143
+
 Room Kit: 1.0.3
 Core SDK: 1.9.2
 Android SDK: 2.8.0

--- a/packages/hmssdk_flutter/example/android/app/build.gradle
+++ b/packages/hmssdk_flutter/example/android/app/build.gradle
@@ -32,8 +32,8 @@ android {
         applicationId "live.hms.flutter"
         minSdkVersion 21
         targetSdkVersion 33
-        versionCode 385
-        versionName "1.5.85"
+        versionCode 386
+        versionName "1.5.86"
     }
 
     signingConfigs {

--- a/packages/hmssdk_flutter/example/ios/Runner/Info.plist
+++ b/packages/hmssdk_flutter/example/ios/Runner/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.85</string>
+	<string>1.5.86</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -48,7 +48,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>385</string>
+	<string>386</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>


### PR DESCRIPTION
# Description

- Removed `setVolume` call in returning to foreground service.

### Pre-launch Checklist

- [X] The [Documentation] is updated accordingly, or this PR doesn't require it.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I added new tests to check the change I am making, or this PR is test-exempt.
- [X] All existing and new tests are passing.

<!-- Links -->
[Documentation]: https://www.100ms.live/docs
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
