### PR TITLE
FLUT-158: Added feature to disable name edit on preview

### DIFF
--- a/packages/hms_room_kit/lib/src/preview/preview_page.dart
+++ b/packages/hms_room_kit/lib/src/preview/preview_page.dart
@@ -322,6 +322,7 @@ class _PreviewPageState extends State<PreviewPage> {
                                                         height: 48,
                                                         width: width * 0.50,
                                                         child: TextField(
+                                                          enabled: widget.name.trim().isEmpty,
                                                           cursorColor:
                                                               HMSThemeColors
                                                                   .onSurfaceHighEmphasis,

--- a/packages/hms_room_kit/lib/src/screen_controller.dart
+++ b/packages/hms_room_kit/lib/src/screen_controller.dart
@@ -158,7 +158,7 @@ class _ScreenControllerState extends State<ScreenController> {
                   value: _previewStore,
                   child: PreviewPage(
                     roomCode: Constant.roomCode,
-                    name: widget.options?.userName ?? "",
+                    name: widget.options?.userName?.trim() ?? "",
                     options: widget.options,
                   ))
               : PreviewPermissions(


### PR DESCRIPTION
# Description

- Added feature to disable name editing on preview if `userName` is sent from `prebuiltOptions`

### Pre-launch Checklist

- [X] The [Documentation] is updated accordingly, or this PR doesn't require it.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I added new tests to check the change I am making, or this PR is test-exempt.
- [X] All existing and new tests are passing.

<!-- Links -->
[Documentation]: https://www.100ms.live/docs
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
