### PR TITLE
Added addTrack call explicitly

### DIFF
--- a/packages/hmssdk_flutter/lib/src/ui/meeting/hms_texture_view.dart
+++ b/packages/hmssdk_flutter/lib/src/ui/meeting/hms_texture_view.dart
@@ -118,6 +118,14 @@ class _PlatformViewState extends State<_PlatformView> {
                 widget.disableAutoSimulcastLayerSelect);
       } else {
         viewController = widget.controller;
+
+        ///Calling Add Track with new track in case where the addTrack is not called by the app
+        if (!widget.track.isMute) {
+          viewController?.addTrack(
+              track: widget.track as HMSVideoTrack,
+              disableAutoSimulcastLayerSelect:
+                  widget.disableAutoSimulcastLayerSelect);
+        }
       }
 
       ///Here we set the callback method which gets called to set the view


### PR DESCRIPTION
# Description

- Fixed a bug where addTrack was not getting called with new track in `HMSTextureView`.

### Pre-launch Checklist

- [X] The [Documentation] is updated accordingly, or this PR doesn't require it.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I added new tests to check the change I am making, or this PR is test-exempt.
- [X] All existing and new tests are passing.


<!-- Links -->
[Documentation]: https://www.100ms.live/docs
[ExampleAppChangelog]: https://github.com/100mslive/100ms-flutter/blob/main/packages/hmssdk_flutter/example/ExampleAppChangelog.txt
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
