### PR TITLE
Fix: Username is not honoured while skip preview is true

### DIFF
--- a/packages/hms_room_kit/lib/src/preview_meeting_flow.dart
+++ b/packages/hms_room_kit/lib/src/preview_meeting_flow.dart
@@ -42,7 +42,9 @@ class _PreviewMeetingFlowState extends State<PreviewMeetingFlow> {
   Widget build(BuildContext context) {
     return HMSRoomLayout.skipPreview
         ? MeetingScreenController(
-            user: widget.prebuiltOptions?.userId ?? "",
+            user: widget.prebuiltOptions?.userName ??
+                widget.prebuiltOptions?.userId ??
+                "",
             localPeerNetworkQuality: null,
             options: widget.prebuiltOptions,
             tokenData: widget.tokenData,

--- a/packages/hms_room_kit/lib/src/widgets/bottom_sheets/change_role_bottom_sheet.dart
+++ b/packages/hms_room_kit/lib/src/widgets/bottom_sheets/change_role_bottom_sheet.dart
@@ -83,7 +83,8 @@ class ChangeRoleBottomSheetState extends State<ChangeRoleBottomSheet> {
                 child: HMSDropDown(
                     dropDownItems: <DropdownMenuItem>[
                   ...widget.roles
-                      .where((role) => ((role.name != widget.peer.role.name) && (role.name != '__internal_recorder')))
+                      .where((role) => ((role.name != widget.peer.role.name) &&
+                          (role.name != '__internal_recorder')))
                       .sortedBy((element) => element.priority.toString())
                       .map((role) => DropdownMenuItem(
                             value: role,

--- a/packages/hms_room_kit/lib/src/widgets/bottom_sheets/remote_peer_bottom_sheet.dart
+++ b/packages/hms_room_kit/lib/src/widgets/bottom_sheets/remote_peer_bottom_sheet.dart
@@ -222,8 +222,9 @@ class _RemotePeerBottomSheetState extends State<RemotePeerBottomSheet> {
                                 ? HMSThemeColors.onSurfaceLowEmphasis
                                 : HMSThemeColors.onSurfaceHighEmphasis)),
                   if ((widget.meetingStore.localPeer?.role.permissions
-                          .changeRole ??
-                      false) && (widget.meetingStore.roles.length > 1))
+                              .changeRole ??
+                          false) &&
+                      (widget.meetingStore.roles.length > 1))
                     ListTile(
                         horizontalTitleGap: 2,
                         onTap: () async {

--- a/packages/hms_room_kit/lib/src/widgets/common_widgets/message_container.dart
+++ b/packages/hms_room_kit/lib/src/widgets/common_widgets/message_container.dart
@@ -97,9 +97,7 @@ class MessageContainer extends StatelessWidget {
                     mainAxisAlignment: MainAxisAlignment.end,
                     children: [
                       HMSSubtitleText(
-                        text: message.time == null
-                            ? ""
-                            : formatter.format(message.time!),
+                        text: formatter.format(message.time),
                         textColor: HMSThemeColors.onSurfaceMediumEmphasis,
                       ),
                       const SizedBox(


### PR DESCRIPTION
# Description

- Username is not honoured while skip preview is `true`

### Pre-launch Checklist

- [X] The [Documentation] is updated accordingly, or this PR doesn't require it.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I added new tests to check the change I am making, or this PR is test-exempt.
- [X] All existing and new tests are passing.

<!-- Links -->
[Documentation]: https://www.100ms.live/docs
[ExampleAppChangelog]: https://github.com/100mslive/100ms-flutter/blob/main/packages/hmssdk_flutter/example/ExampleAppChangelog.txt
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
