### PR TITLE
fix: restore missing Bluetooth permissions on Android

### DIFF
--- a/packages/hmssdk_flutter/android/src/main/AndroidManifest.xml
+++ b/packages/hmssdk_flutter/android/src/main/AndroidManifest.xml
@@ -3,7 +3,12 @@
     package="live.hms.hmssdk_flutter">
     <uses-feature android:name="android.hardware.camera"/>
     <uses-feature android:name="android.hardware.camera.autofocus"/>
-    
+
+    <!-- Required for Bluetooth audio devices on Android 11 and below -->
+    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
+    <!-- Required for Bluetooth audio devices on Android 12+ -->
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+
     <application>
         <activity android:name=".SecondActivity"></activity>
     </application>

--- a/packages/hmssdk_flutter/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/hmssdk_flutter/example/android/app/src/main/AndroidManifest.xml
@@ -10,6 +10,10 @@
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
 
+    <!-- Required for Bluetooth audio devices -->
+    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+
     <!--Required for android 14 and above -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
 


### PR DESCRIPTION
## Summary

- Bluetooth audio devices are not recognized on Android since the v1.10.0 → v1.11.0 migration — only `AUTOMATIC` appears in the audio device list, `BLUETOOTH` is missing.
- Root cause: commit `4c5fb252` ("removed bluetooth permissions", Jan 2024) intentionally removed `BLUETOOTH` and `BLUETOOTH_CONNECT` from both the SDK manifest and the example app manifest.
- The sample apps were later corrected in `14170aee` (Jun 2024) to re-add these permissions, but the SDK manifest and example app were never updated — creating an inconsistency where sample apps work but the SDK itself and its example app do not.
- This PR restores the permissions in:
  - **SDK manifest** (`packages/hmssdk_flutter/android/src/main/AndroidManifest.xml`) — automatically merged into all consuming apps via Android manifest merging
  - **Example app manifest** (`packages/hmssdk_flutter/example/android/app/src/main/AndroidManifest.xml`) — for explicitness