### PR TITLE
Develop

### DIFF
--- a/packages/hms_room_kit/CHANGELOG.md
+++ b/packages/hms_room_kit/CHANGELOG.md
@@ -6,6 +6,21 @@
 | hmssdk_flutter   | [![Pub Version](https://img.shields.io/pub/v/hmssdk_flutter)](https://pub.dev/packages/hmssdk_flutter)     |
 | hms_video_plugin | [![Pub Version](https://img.shields.io/pub/v/hms_video_plugin)](https://pub.dev/packages/hms_video_plugin) |
 
+# 1.2.1 - 2026-04-10
+
+| Package        | Version |
+| -------------- | ------- |
+| hms_room_kit   | 1.2.1   |
+| hmssdk_flutter | 1.11.1  |
+
+### Added
+
+- Request `BLUETOOTH_CONNECT` runtime permission on Android 12+ alongside camera and microphone for Bluetooth audio device support.
+
+### Changed
+
+- Updated `hmssdk_flutter` dependency to 1.11.1.
+
 # 1.2.0 - 2025-10-29
 
 | Package        | Version |

--- a/packages/hms_room_kit/pubspec.yaml
+++ b/packages/hms_room_kit/pubspec.yaml
@@ -1,6 +1,6 @@
 name: hms_room_kit
 description: 100ms Room Kit provides simple & easy to use UI components to build Live Streaming & Video Conferencing experiences in your apps.
-version: 1.2.0
+version: 1.2.1
 homepage: https://www.100ms.live/
 repository: https://github.com/100mslive/100ms-flutter
 issue_tracker: https://github.com/100mslive/100ms-flutter/issues
@@ -14,7 +14,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  hmssdk_flutter: 1.11.0
+  hmssdk_flutter: 1.11.1
   intl: ^0.20.2
   permission_handler: ^12.0.1
   provider: ^6.1.5+1

--- a/packages/hmssdk_flutter/CHANGELOG.md
+++ b/packages/hmssdk_flutter/CHANGELOG.md
@@ -6,6 +6,20 @@
 | hmssdk_flutter   | [![Pub Version](https://img.shields.io/pub/v/hmssdk_flutter)](https://pub.dev/packages/hmssdk_flutter)     |
 | hms_video_plugin | [![Pub Version](https://img.shields.io/pub/v/hms_video_plugin)](https://pub.dev/packages/hms_video_plugin) |
 
+# 1.11.1 - 2026-04-10
+
+| Package        | Version |
+| -------------- | ------- |
+| hms_room_kit   | 1.2.0   |
+| hmssdk_flutter | 1.11.1  |
+
+### Fixed
+
+- Fixed Bluetooth audio devices not appearing in `getAudioDevicesList()` on Android 12+.
+- Added `BLUETOOTH_CONNECT` permission to Android manifest for Bluetooth audio device discovery.
+- Added `AUTOMATIC` option to the audio device list on Android 12+.
+- Updated native Android SDK to 2.9.83.
+
 # 1.11.0 - 2025-10-29
 
 | Package        | Version |

--- a/packages/hmssdk_flutter/pubspec.lock
+++ b/packages/hmssdk_flutter/pubspec.lock
@@ -111,10 +111,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -172,10 +172,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   vector_math:
     dependency: transitive
     description:


### PR DESCRIPTION
- Add release notes for Android native SDK v2.9.82 and v2.9.83 (Bluetooth audio device 
  fixes on Android 12+)
- Add release notes for Flutter SDK 1.11.1 with hms_room_kit 1.2.1 (Bluetooth          
  permission support)      